### PR TITLE
Fix variable names in messages

### DIFF
--- a/Standards/FuelPHP/Sniffs/NamingConventions/ConciseUnderscoredVariableNameSniff.php
+++ b/Standards/FuelPHP/Sniffs/NamingConventions/ConciseUnderscoredVariableNameSniff.php
@@ -88,13 +88,15 @@ class FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff
         if (FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff::isUnderscoreName($name) === false) {
             $error = 'Variable name "%s" does not use underscore format.
                 Upper case forbidden.';
-            $phpcsFile->addError($error, $stackPtr, 'NotUnderscore');
+            $data  = array($varName);
+            $phpcsFile->addError($error, $stackPtr, 'NotUnderscore', $data);
         }
 
         if (strlen($name) > $this->maxlength) {
             $warning = 'Variable name "%s" should be more concise.
                 Actually more than ' . $this->maxlength . ' chars.';
-            $phpcsFile->addWarning($warning, $stackPtr, 'VariableNameTooLong');
+            $data  = array($varName);
+            $phpcsFile->addWarning($warning, $stackPtr, 'VariableNameTooLong', $data);
         }
     }
 }

--- a/Standards/FuelPHP/Sniffs/NamingConventions/ConciseUnderscoredVariableNameSniff.php
+++ b/Standards/FuelPHP/Sniffs/NamingConventions/ConciseUnderscoredVariableNameSniff.php
@@ -88,14 +88,14 @@ class FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff
         if (FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff::isUnderscoreName($name) === false) {
             $error = 'Variable name "%s" does not use underscore format.
                 Upper case forbidden.';
-            $data  = array($varName);
+            $data  = array($name);
             $phpcsFile->addError($error, $stackPtr, 'NotUnderscore', $data);
         }
 
         if (strlen($name) > $this->maxlength) {
             $warning = 'Variable name "%s" should be more concise.
                 Actually more than ' . $this->maxlength . ' chars.';
-            $data  = array($varName);
+            $data  = array($name);
             $phpcsFile->addWarning($warning, $stackPtr, 'VariableNameTooLong', $data);
         }
     }


### PR DESCRIPTION
```
// before
Variable name "%s" does not use underscore format.

// after
Variable name "$varName" does not use underscore format.
```